### PR TITLE
feat(cassandra): added multi-node cluster compose

### DIFF
--- a/cassandra-docker-compose/README.md
+++ b/cassandra-docker-compose/README.md
@@ -1,0 +1,122 @@
+# Cassandra database docker-compose utilities
+
+This directory contains the docker compose utilities for creating a Cassandra multinode database cluster.
+
+## MultiNode Cluster Environment
+
+This project is based on [official docker image](https://hub.docker.com/_/cassandra/) maintained by [Docker Hub](https://docs.docker.com/docker-hub/official_images/) to start a simple multi-node cluster for local development.
+
+> NOTE: This configuration fits most of development environment requirements and is not recommended for production usage.
+
+### Configuration
+
+- This set up will start up a 3-node Cassandra database cluster. You can configure the number of containers in [compose] specification(./cassandra-multi-node-docker-compose.yml/cassandra-multi-node-docker-compose.yml).
+- `data` is stored in [docker volumes](https://docs.docker.com/storage/volumes/#use-a-volume-with-docker-compose) named `cassandra-volume-*` on the host host filesystem which is managed by Docker at `/var/lib/docker/volumes/`.
+- The cluster can be accessed on [client port address](http://localhost:9042).
+
+### Quick start
+
+To start up a local cluster on the machine:
+
+```sh
+cd ./cassandra-docker-compose
+
+## Review the compose config (Optional)
+docker compose -f cassandra-docker-compose.yml config
+
+## Start cluster
+docker compose -f cassandra-docker-compose.yml up
+
+## Or alternatively run in background and check status
+docker compose -f cassandra-docker-compose.yml up -d
+docker compose -f cassandra-docker-compose.yml ps
+```
+
+### Usage
+
+Once cluster is up, you can create keyspaces as you need. You can use [`nodetool`](https://cassandra.apache.org/doc/stable/cassandra/tools/nodetool/nodetool.html) to verify the status and [`cqlsh`](https://cassandra.apache.org/doc/stable/cassandra/tools/cqlsh.html) to create keyspaces and tables.
+
+More information is available [here](https://cassandra.apache.org/_/quickstart.html).
+
+```sh
+## Outputs cluster and gossip status
+docker compose -f cassandra-docker-compose.yml \
+  exec cassandra-1 \
+  nodetool status
+
+docker compose -f cassandra-docker-compose.yml \
+  exec cassandra-1 \
+  nodetool statusgossip
+
+## Run script in cqlsh to seed sample data
+cat <<EOF | docker compose -f cassandra-docker-compose.yml exec \
+  -T cassandra-1 \
+  cqlsh
+
+-- Create a keyspace
+CREATE KEYSPACE IF NOT EXISTS my_store WITH REPLICATION = {
+  'class' : 'SimpleStrategy',
+  'replication_factor' : '1'
+};
+
+-- Create a table
+CREATE TABLE IF NOT EXISTS my_store.shopping_cart (
+  userid text PRIMARY KEY,
+  item_count int,
+  last_update_timestamp timestamp
+);
+
+-- Insert data
+INSERT INTO my_store.shopping_cart (userid, item_count, last_update_timestamp)
+VALUES ('1234', 2, toTimeStamp(now()));
+
+INSERT INTO my_store.shopping_cart (userid, item_count, last_update_timestamp)
+VALUES ('1235', 1, toTimeStamp(now()));  
+
+-- Terminate the shell
+EXIT;
+
+EOF
+
+## Run script in cqlsh to query sample data
+cat <<EOF | docker compose -f cassandra-docker-compose.yml \
+  exec -T cassandra-1 \
+  cqlsh
+
+-- Query data
+SELECT * FROM my_store.shopping_cart;
+
+-- Terminate the shell
+EXIT;
+
+EOF
+```
+
+### Restart the cluster
+
+To restart the running local cluster on the machine:
+
+```sh
+docker compose -f cassandra-docker-compose.yml restart
+```
+
+### Stop the cluster
+
+To stop the running local cluster on the machine:
+
+```sh
+docker compose -f cassandra-docker-compose.yml down
+
+## Or alternatively stop if you have run in detached mode
+docker compose -f cassandra-docker-compose.yml stop
+```
+
+### Remove docker volumes
+
+The volumes created are persisted on disk and survives cluster restarts. To remove the docker volumes created:
+
+```sh
+docker volume rm cassandra-volume-1 \
+  cassandra-volume-2 \
+  cassandra-volume-3
+```

--- a/cassandra-docker-compose/cassandra-docker-compose.yml
+++ b/cassandra-docker-compose/cassandra-docker-compose.yml
@@ -1,0 +1,99 @@
+x-common-labels: &common-labels                                      ## Define project metadata 
+  com.example.partOf: "cassandra-cluster-local"
+  com.example.environment: "development"
+
+x-common-image: &cassandra-image                                     ## Define image version/tag
+  cassandra:5.0                                               
+
+x-common-environment: &cassandra-environment                         ## Define environment variables
+  - CASSANDRA_SEEDS=cassandra-node-1                                 ## Nominate this node as seed node
+  - CASSANDRA_LISTEN_ADDRESS=auto                                    ## The IP address to listen for incoming connections
+  - CASSANDRA_CLUSTER_NAME=cassandra-cluster-local-1                 ## Local cluster name
+  - CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch            ## Automatically propogate information to other nodes via gossip protocol
+  - CASSANDRA_DC=datacenter-1                                        ## Assumes nodes on same datacenter and rack for cassandra snitch
+  - CASSANDRA_RACK=rack-1
+ 
+x-common-healthcheck: &cassandra-node-healthcheck                    ## Use nodetool to determine health status
+  test: ["CMD-SHELL", "nodetool status"]
+  interval: 2m
+  start_period: 2m
+  timeout: 10s
+  retries: 3
+
+networks:
+  cassandra-network:                                                 ## Isolate containers from other networks
+    labels: *common-labels
+    name: cassandra-network
+    driver: bridge
+
+services:
+  cassandra-1:
+    labels: *common-labels
+    image: *cassandra-image
+    container_name: cassandra-node-1                                 ## First container node in the cluster
+    hostname: cassandra-node-1
+    ports: 
+      - 9042:9042                                                    ## Cassandra client port
+      - 9160:9160                                                    ## Cassandra Thrift client port
+      - 7199:7199                                                    ## Cassandra JMX monitoring port
+    volumes:                                                         ## Mount docker volume to persist data
+      - cassandra-volume-1:/var/lib/cassandra:rw
+    environment: *cassandra-environment
+    healthcheck: *cassandra-node-healthcheck
+    restart: on-failure                                              ## Restart when container exits with error
+    networks:                                                        ## Run in user defined network
+      - cassandra-network
+
+  cassandra-2:
+    labels: *common-labels
+    image: *cassandra-image
+    container_name: cassandra-node-2                                 ## Second container node in the cluster
+    hostname: cassandra-node-2
+    ports: 
+      - 9043:9042                                                    ## Cassandra client port. Avoid port conflicts, if nodes run on same machine
+      - 9161:9160                                                    ## Cassandra Thrift client port
+      - 7200:7199                                                    ## Cassandra JMX monitoring port
+    volumes:                                                         ## Mount docker volume to persist data
+      - cassandra-volume-2:/var/lib/cassandra:rw
+    environment: *cassandra-environment
+    healthcheck: *cassandra-node-healthcheck
+    restart: on-failure                                              ## Restart when container exits with error
+    depends_on:                                                      ## Defines start up order, wait for cassandra-1 health check to pass
+      cassandra-1:
+        condition: service_healthy
+    networks:                                                        ## Run in user defined network
+      - cassandra-network
+
+  cassandra-3:
+    labels: *common-labels
+    image: *cassandra-image
+    container_name: cassandra-node-3                                 ## Third container node in the cluster
+    hostname: cassandra-node-3
+    ports: 
+      - 9044:9042                                                    ## Cassandra client port. Avoid port conflicts, if nodes run on same machine
+      - 9162:9160                                                    ## Cassandra Thrift client port
+      - 7201:7199                                                    ## Cassandra JMX monitoring port
+    volumes:                                                         ## Mount docker volume to persist data
+      - cassandra-volume-3:/var/lib/cassandra:rw
+    environment: *cassandra-environment
+    healthcheck: *cassandra-node-healthcheck
+    restart: on-failure                                              ## Restart when container exits with error
+    depends_on:                                                      ## Defines start up order, wait for cassandra-2 health check to pass
+      cassandra-2:
+        condition: service_healthy
+    networks:                                                        ## Run in user defined network
+      - cassandra-network
+  
+volumes:                                                             ## Docker managed volume specifications
+  cassandra-volume-1:
+    labels: *common-labels
+    name: cassandra-volume-1
+    driver: local                                                    ## Prefer volume on host machine
+  cassandra-volume-2:
+    labels: *common-labels
+    name: cassandra-volume-2
+    driver: local                                                    ## Prefer volume on host machine
+  cassandra-volume-3:
+    labels: *common-labels
+    name: cassandra-volume-3
+    driver: local                                                    ## Prefer volume on host machine


### PR DESCRIPTION
**What?**

- Added docker compose configuration to start a simple multi-node [Cassandra](https://cassandra.apache.org/_/index.html) database cluster.
- Instructions added in README.md for quick start

**Changes**

- cassandra-docker-compose/README.md
- cassandra-docker-compose/cassandra-docker-compose.yml

Closes #16